### PR TITLE
Added check for font size being <= than 0

### DIFF
--- a/Source/YoloSharp/Services/Plotting/Drawers/NameDrawer.cs
+++ b/Source/YoloSharp/Services/Plotting/Drawers/NameDrawer.cs
@@ -7,6 +7,10 @@ internal class NameDrawer : INameDrawer
     public void DrawName(YoloPrediction prediction, PointF position, bool inside, PlottingContext context)
     {
         var font = context.TextOptions.Font;
+        
+        if (font.Size <= 0)
+            return;
+        
         var xPadding = context.NamePadding.X;
         var yPadding = context.NamePadding.Y;
 


### PR DESCRIPTION
When the Font size is less or equal to 0 when plotting, the code gets stuck.

This also enables a option to turn off the text writing when plotting