### PR TITLE
OnnxRuntime Package Reference Split

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
         run: |
           dotnet build -c Release Source/YoloSharp/YoloSharp.csproj -p:Version=${{ env.VERSION }}
           dotnet build -c GpuRelease Source/YoloSharp/YoloSharp.csproj -p:Version=${{ env.VERSION }}
+          dotnet build -c GpuLinuxRelease Source/YoloSharp/YoloSharp.csproj -p:Version=${{ env.VERSION }}
+          dotnet build -c GpuWindowsRelease Source/YoloSharp/YoloSharp.csproj -p:Version=${{ env.VERSION }}
 
       - name: Test
         run: dotnet test Source/YoloSharp.Tests/YoloSharp.Tests.csproj
@@ -36,6 +38,8 @@ jobs:
         run: |
           dotnet pack -c Release -o . Source/YoloSharp/YoloSharp.csproj -p:Version=${{ env.VERSION }}
           dotnet pack -c GpuRelease -o . Source/YoloSharp/YoloSharp.csproj -p:Version=${{ env.VERSION }}
+          dotnet pack -c GpuLinuxRelease -o . Source/YoloSharp/YoloSharp.csproj -p:Version=${{ env.VERSION }}
+          dotnet pack -c GpuWindowsRelease -o . Source/YoloSharp/YoloSharp.csproj -p:Version=${{ env.VERSION }}
 
       - name: Publish
         run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -1,17 +1,18 @@
 <Project>
     <PropertyGroup>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-		 <OnnxRuntimeVersion>1.22.0</OnnxRuntimeVersion>
+        <OnnxRuntimePackage>Microsoft.ML.OnnxRuntime</OnnxRuntimePackage>
+        <OnnxRuntimeVersion>1.22.0</OnnxRuntimeVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="Clipper2" Version="1.5.4" />
         <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.10" />
         <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-        <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" />
-        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu" Version="$(OnnxRuntimeVersion)" />
-        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" Version="$(OnnxRuntimeVersion)" />
-        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="$(OnnxRuntimeVersion)" />
+        <PackageVersion Include="$(OnnxRuntimePackage)" Version="$(OnnxRuntimeVersion)" />
+        <PackageVersion Include="$(OnnxRuntimePackage).Gpu" Version="$(OnnxRuntimeVersion)" />
+        <PackageVersion Include="$(OnnxRuntimePackage).Gpu.Linux" Version="$(OnnxRuntimeVersion)" />
+        <PackageVersion Include="$(OnnxRuntimePackage).Gpu.Windows" Version="$(OnnxRuntimeVersion)" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1">

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -1,16 +1,17 @@
 <Project>
     <PropertyGroup>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+		 <OnnxRuntimeVersion>1.22.0</OnnxRuntimeVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="Clipper2" Version="1.5.4" />
         <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.10" />
         <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-        <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
-        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.22.0" />
-        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" Version="1.22.0" />
-        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.0" />
+        <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" />
+        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu" Version="$(OnnxRuntimeVersion)" />
+        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" Version="$(OnnxRuntimeVersion)" />
+        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="$(OnnxRuntimeVersion)" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageVersion Include="xunit" Version="2.9.3" />
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1">

--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -1,0 +1,25 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="Clipper2" Version="1.5.4" />
+        <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.10" />
+        <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+        <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
+        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.22.0" />
+        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" Version="1.22.0" />
+        <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageVersion Include="xunit" Version="2.9.3" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+        <PackageVersion Include="coverlet.collector" Version="6.0.4">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+    </ItemGroup>
+</Project>

--- a/Source/YoloSharp.Demo/YoloSharp.Demo.csproj
+++ b/Source/YoloSharp.Demo/YoloSharp.Demo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>

--- a/Source/YoloSharp.Tests/YoloSharp.Tests.csproj
+++ b/Source/YoloSharp.Tests/YoloSharp.Tests.csproj
@@ -17,13 +17,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Source/YoloSharp/Predictor/YoloPredictorOptions.cs
+++ b/Source/YoloSharp/Predictor/YoloPredictorOptions.cs
@@ -4,7 +4,7 @@ public class YoloPredictorOptions
 {
     public static YoloPredictorOptions Default { get; } = new();
 
-#if GPURELEASE
+#if GPURELEASE || GPULINUXRELEASE || GPUWINDOWSRELEASE
     public bool UseCuda { get; init; } = true;
 #else 
     public bool UseCuda { get; init; }

--- a/Source/YoloSharp/YoloSharp.csproj
+++ b/Source/YoloSharp/YoloSharp.csproj
@@ -6,26 +6,28 @@
 		<Nullable>enable</Nullable>
 		<RootNamespace>Compunet.YoloSharp</RootNamespace>
 		<IsAotCompatible>true</IsAotCompatible>
+		<BasePackageId>YoloSharp</BasePackageId>
+		<BaseAssemblyName>YoloSharp</BaseAssemblyName>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
-		<PackageId>YoloSharp</PackageId>
-		<AssemblyName>YoloSharp</AssemblyName>
+		<PackageId>$(BasePackageId)</PackageId>
+		<AssemblyName>$(BaseAssemblyName)</AssemblyName>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'GpuRelease'">
-		<PackageId>YoloSharp.Gpu</PackageId>
-		<AssemblyName>YoloSharp.Gpu</AssemblyName>
+		<PackageId>$(BasePackageId).Gpu</PackageId>
+		<AssemblyName>$(BaseAssemblyName).Gpu</AssemblyName>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'GpuLinuxRelease'">
-		<PackageId>YoloSharp.Gpu.Linux</PackageId>
-		<AssemblyName>YoloSharp.Gpu.Linux</AssemblyName>
+		<PackageId>$(BasePackageId).Gpu.Linux</PackageId>
+		<AssemblyName>$(BaseAssemblyName).Gpu.Linux</AssemblyName>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'GpuWindowsRelease'">
-		<PackageId>YoloSharp.Gpu.Windows</PackageId>
-		<AssemblyName>YoloSharp.Gpu.Windows</AssemblyName>
+		<PackageId>$(BasePackageId).Gpu.Windows</PackageId>
+		<AssemblyName>$(BaseAssemblyName).Gpu.Windows</AssemblyName>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Release' OR '$(Configuration)' == 'GpuRelease' OR '$(Configuration)' == 'GpuLinuxRelease' OR '$(Configuration)' == 'GpuWindowsRelease'">

--- a/Source/YoloSharp/YoloSharp.csproj
+++ b/Source/YoloSharp/YoloSharp.csproj
@@ -18,7 +18,17 @@
 		<AssemblyName>YoloSharp.Gpu</AssemblyName>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)' == 'Release' OR '$(Configuration)' == 'GpuRelease'">
+	<PropertyGroup Condition="'$(Configuration)' == 'GpuLinuxRelease'">
+		<PackageId>YoloSharp.Gpu.Linux</PackageId>
+		<AssemblyName>YoloSharp.Gpu.Linux</AssemblyName>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)' == 'GpuWindowsRelease'">
+		<PackageId>YoloSharp.Gpu.Windows</PackageId>
+		<AssemblyName>YoloSharp.Gpu.Windows</AssemblyName>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)' == 'Release' OR '$(Configuration)' == 'GpuRelease' OR '$(Configuration)' == 'GpuLinuxRelease' OR '$(Configuration)' == 'GpuWindowsRelease'">
 		<Optimize>true</Optimize>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Description>Use YOLO11 in real-time for object detection tasks, with edge performance, powered by ONNX-Runtime.</Description>
@@ -41,8 +51,10 @@
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-		<PackageReference Condition="'$(Configuration)' != 'GpuRelease'" Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
+		<PackageReference Condition="'$(Configuration)' == 'Release' OR '$(Configuration)' == 'Debug'" Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
 		<PackageReference Condition="'$(Configuration)' == 'GpuRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.22.0" />
+		<PackageReference Condition="'$(Configuration)' == 'GpuLinuxRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" Version="1.22.0" />
+		<PackageReference Condition="'$(Configuration)' == 'GpuWindowsRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.0" />
 	</ItemGroup>
 
 </Project>

--- a/Source/YoloSharp/YoloSharp.csproj
+++ b/Source/YoloSharp/YoloSharp.csproj
@@ -47,14 +47,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Clipper2" Version="1.5.4" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
-		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-		<PackageReference Condition="'$(Configuration)' == 'Release' OR '$(Configuration)' == 'Debug'" Include="Microsoft.ML.OnnxRuntime" Version="1.22.0" />
-		<PackageReference Condition="'$(Configuration)' == 'GpuRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.22.0" />
-		<PackageReference Condition="'$(Configuration)' == 'GpuLinuxRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" Version="1.22.0" />
-		<PackageReference Condition="'$(Configuration)' == 'GpuWindowsRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" Version="1.22.0" />
+		<PackageReference Include="Clipper2" />
+		<PackageReference Include="SixLabors.ImageSharp" />
+		<PackageReference Include="SixLabors.ImageSharp.Drawing" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Condition="'$(Configuration)' == 'Release' OR '$(Configuration)' == 'Debug'" Include="Microsoft.ML.OnnxRuntime" />
+		<PackageReference Condition="'$(Configuration)' == 'GpuRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu" />
+		<PackageReference Condition="'$(Configuration)' == 'GpuLinuxRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" />
+		<PackageReference Condition="'$(Configuration)' == 'GpuWindowsRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu.Windows" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
I will release 'YoloSharp. Gpu' to the production environment, and each time the dependency file is very large. Can it be split according to the system.