### PR TITLE
Fix Nuget Health Check and improve Build binary traceability

### DIFF
--- a/Source/YoloSharp/YoloSharp.csproj
+++ b/Source/YoloSharp/YoloSharp.csproj
@@ -24,13 +24,22 @@
 		<AssemblyName>$(PackageName)</AssemblyName>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Description>Use YOLO11 in real-time for object detection tasks, with edge performance, powered by ONNX-Runtime.</Description>
-		<RepositoryUrl>https://github.com/dme-compunet/YoloSharp</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/dme-compunet/YoloSharp</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/dme-compunet/YoloSharp.git</RepositoryUrl>
 		<PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageTags>image-classification object-detection pose-estimation instance-segmentation onnx imagesharp onnx-runtime ultralytics yolov8 yolov10 yolo11 yolov12</PackageTags>
 		<PackageIcon>Icon.png</PackageIcon>
 		<Authors>Compunet</Authors>
 		<Version>6.0.6</Version>
+		<Deterministic>true</Deterministic>
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+
+	<!-- Ensure nuget show deterministic tag as valid, https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/#deterministic-builds -->
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This pull request makes changes to the release builds to ensure that the NuGet Health Check shows as valid and that users can confirm the uploaded binary was built as-is from this repository, without any code modifications.

1. Release builds are now deterministic. This means that if someone takes a specific release version and builds it themselves on their machine, the compiled binary will always have the same hash as the release version.
2. We now include debug information inside the DLL file, which allows us to gather more details about the build source code and provides more detailed information during debugging.

If you check the latest version (6.0.6), you'll see that it fails the Health Check. Additionally, there is no fool proof way to confirm that the binary was built exactly as-is from this repo source code: https://nuget.info/packages/YoloSharp/6.0.6.

Here’s an example using one of my own libraries, where you can see the health check. If you select a DLL file, you’ll also be able to view the source code along with the debug information : https://nuget.info/packages/SubtitlesParserV2/2.3.0 .