### PR TITLE
Choosing a resampling algorithm

### DIFF
--- a/src/YoloSharp/Metadata/YoloImageResampler.cs
+++ b/src/YoloSharp/Metadata/YoloImageResampler.cs
@@ -1,0 +1,18 @@
+﻿namespace Compunet.YoloSharp.Metadata;
+
+/// <summary>
+/// Specifies the resampling algorithm used when resizing input images.
+/// </summary>
+public enum YoloImageResampler
+{
+    Bicubic,
+    Triangle,
+    NearestNeighbor,
+    Lancos2,
+    Lanczos3,
+    Lanczos5,
+    Lanczos8,
+    Spline,
+    Box,
+    Hermite
+}

--- a/src/YoloSharp/Metadata/YoloImageResampler.cs
+++ b/src/YoloSharp/Metadata/YoloImageResampler.cs
@@ -8,7 +8,7 @@ public enum YoloImageResampler
     Bicubic,
     Triangle,
     NearestNeighbor,
-    Lancos2,
+    Lanczos2,
     Lanczos3,
     Lanczos5,
     Lanczos8,

--- a/src/YoloSharp/Predictor/YoloConfiguration.cs
+++ b/src/YoloSharp/Predictor/YoloConfiguration.cs
@@ -35,6 +35,11 @@ public class YoloConfiguration : IEquatable<YoloConfiguration>
     /// </summary>
     public bool SuppressParallelInference { get; set; } = false;
 
+    /// <summary>
+    /// The resampling algorithm. Bicubic - recommended in the ImageSharp documentation
+    /// </summary>
+    public IResampler ImageResampler { get; set; } = KnownResamplers.Bicubic;
+
     public bool Equals(YoloConfiguration? other)
     {
         if (other is null)

--- a/src/YoloSharp/Predictor/YoloConfiguration.cs
+++ b/src/YoloSharp/Predictor/YoloConfiguration.cs
@@ -40,7 +40,22 @@ public class YoloConfiguration : IEquatable<YoloConfiguration>
     /// <summary>
     /// The resampling algorithm. Bicubic - recommended in the ImageSharp documentation
     /// </summary>
-    public IResampler ImageResampler { get; set; } = KnownResamplers.Bicubic;
+    public YoloImageResampler ImageResampler { get; set; } = YoloImageResampler.NearestNeighbor;
+
+    internal IResampler GetImageResampler() => ImageResampler switch
+    {
+        YoloImageResampler.Bicubic => KnownResamplers.Bicubic,
+        YoloImageResampler.NearestNeighbor => KnownResamplers.NearestNeighbor,
+        YoloImageResampler.Box => KnownResamplers.Box,
+        YoloImageResampler.Triangle => KnownResamplers.Triangle,
+        YoloImageResampler.Hermite => KnownResamplers.Hermite,
+        YoloImageResampler.Lancos2 => KnownResamplers.Lanczos2,
+        YoloImageResampler.Lanczos3 => KnownResamplers.Lanczos3,
+        YoloImageResampler.Lanczos5 => KnownResamplers.Lanczos5,
+        YoloImageResampler.Lanczos8 => KnownResamplers.Lanczos8,
+        YoloImageResampler.Spline => KnownResamplers.Spline,
+        _ => KnownResamplers.NearestNeighbor
+    };
 
     public bool Equals(YoloConfiguration? other)
     {

--- a/src/YoloSharp/Predictor/YoloConfiguration.cs
+++ b/src/YoloSharp/Predictor/YoloConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace Compunet.YoloSharp;
+using SixLabors.ImageSharp.Processing.Processors.Transforms;
+
+namespace Compunet.YoloSharp;
 
 /// <summary>
 /// Configuration settings for the YoloPredictor.

--- a/src/YoloSharp/Predictor/YoloConfiguration.cs
+++ b/src/YoloSharp/Predictor/YoloConfiguration.cs
@@ -49,7 +49,7 @@ public class YoloConfiguration : IEquatable<YoloConfiguration>
         YoloImageResampler.Box => KnownResamplers.Box,
         YoloImageResampler.Triangle => KnownResamplers.Triangle,
         YoloImageResampler.Hermite => KnownResamplers.Hermite,
-        YoloImageResampler.Lancos2 => KnownResamplers.Lanczos2,
+        YoloImageResampler.Lanczos2 => KnownResamplers.Lanczos2,
         YoloImageResampler.Lanczos3 => KnownResamplers.Lanczos3,
         YoloImageResampler.Lanczos5 => KnownResamplers.Lanczos5,
         YoloImageResampler.Lanczos8 => KnownResamplers.Lanczos8,

--- a/src/YoloSharp/Services/Predictor/SerssionRunnerService.cs
+++ b/src/YoloSharp/Services/Predictor/SerssionRunnerService.cs
@@ -167,7 +167,7 @@ internal class SessionRunner(YoloSession yoloSession,
                    : ResizeMode.Stretch,
 
             // Select faster resampling algorithm
-            Sampler = KnownResamplers.NearestNeighbor
+            Sampler = KnownResamplers.Bicubic
         };
 
         // Create resized image

--- a/src/YoloSharp/Services/Predictor/SerssionRunnerService.cs
+++ b/src/YoloSharp/Services/Predictor/SerssionRunnerService.cs
@@ -167,7 +167,7 @@ internal class SessionRunner(YoloSession yoloSession,
                    : ResizeMode.Stretch,
 
             // Resampling algorithm
-            Sampler = configuration.ImageResampler
+            Sampler = configuration.GetImageResampler()
         };
 
         // Create resized image

--- a/src/YoloSharp/Services/Predictor/SerssionRunnerService.cs
+++ b/src/YoloSharp/Services/Predictor/SerssionRunnerService.cs
@@ -166,8 +166,8 @@ internal class SessionRunner(YoloSession yoloSession,
                    ? ResizeMode.Max
                    : ResizeMode.Stretch,
 
-            // Select faster resampling algorithm
-            Sampler = KnownResamplers.Bicubic
+            // Resampling algorithm
+            Sampler = configuration.ImageResampler
         };
 
         // Create resized image


### PR DESCRIPTION
Replacing nearest neighbor with Bicubic. Greatly increases the recognition accuracy at very small image.
Closes https://github.com/dme-compunet/YoloSharp/issues/200

Nearest neighbor
<img width="100" height="31" alt="YoloSharp orig" src="https://github.com/user-attachments/assets/1d10a386-ed31-42f6-adc4-29c594bafbba" />

Bicubic
<img width="100" height="31" alt="result YoloSharp 2 0" src="https://github.com/user-attachments/assets/8d776ec3-86fb-4529-8751-c9c9bb46c14b" />